### PR TITLE
일관된 에러처리 / 리스폰스 API 리팩토링 / 스탯 API 테스트

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,10 @@
 {
   "extends": ["plugin:prettier/recommended"],
 
-  "plugins": ["prettier"],
+  "plugins": ["prettier", "unicorn"],
 
   "rules": {
-    "prettier/prettier": "warning"
+    "prettier/prettier": "warning",
+    "unicorn/catch-error-name": ["error", { "name": "error" }]
   }
 }

--- a/Controller/mbtiController.js
+++ b/Controller/mbtiController.js
@@ -5,10 +5,12 @@ export const createMbti = async (req, res) => {
   try {
     const { mbti_data } = req.body;
     return await getMbti(mbti_data);
-  } catch (err) {
+  } catch (error) {
     res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-      message: 'Failed to create MBTI',
-      error: err,
+      error: {
+        status: StatusCodes.INTERNAL_SERVER_ERROR,
+        message: 'Failed to update MBTI',
+      },
     });
   }
 };

--- a/Controller/mbtiController.js
+++ b/Controller/mbtiController.js
@@ -6,8 +6,10 @@ export const createMbti = async (req, res) => {
     const { mbti_data } = req.body;
     return await getMbti(mbti_data);
   } catch (error) {
+    console.log(error);
     res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
       error: {
+        sucess: false,
         status: StatusCodes.INTERNAL_SERVER_ERROR,
         message: 'Failed to update MBTI',
       },
@@ -39,19 +41,24 @@ export const updateMbti = async (req, res) => {
 
   try {
     const [result] = await pool.execute(query, values);
-    if (result.affectedRows > 0) {
-      res.status(StatusCodes.OK).json({
-        message: 'MBTI updated successfully',
-      });
-    } else {
-      res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-        message: 'Failed to update MBTI',
+
+    if (result.affectedRows === 0) {
+      return res.status(StatusCodes.NOT_FOUND).json({
+        sucess: false,
+        status: StatusCodes.NOT_FOUND,
+        message: 'MBTI not found',
       });
     }
-  } catch (err) {
+
+    res.status(StatusCodes.OK).json({
+      message: 'MBTI updated successfully',
+    });
+  } catch (error) {
+    console.log(error);
     res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      sucess: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
       message: 'Failed to update MBTI',
-      error: err,
     });
   }
 };
@@ -59,21 +66,26 @@ export const updateMbti = async (req, res) => {
 // MBTI에 있는 JSON 데이터 출력
 export const getMbtiData = async (req, res) => {
   const { userId } = req.params;
-  let query = `SELECT mbti FROM users WHERE user_id = ?`;
+  const query = `SELECT mbti FROM users WHERE user_id = ?`;
 
   try {
     const [rows] = await pool.execute(query, [userId]);
-    if (rows.length > 0) {
-      res.status(StatusCodes.OK).json(rows[0].mbti);
-    } else {
-      res.status(StatusCodes.NOT_FOUND).json({
+
+    if (rows.length === 0) {
+      return res.status(StatusCodes.NOT_FOUND).json({
+        sucess: false,
+        status: StatusCodes.NOT_FOUND,
         message: 'MBTI not found',
       });
     }
-  } catch (err) {
+
+    res.status(StatusCodes.OK).json(rows[0].mbti);
+  } catch (error) {
+    console.log(error);
     res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      sucess: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
       message: 'Failed to retrieve MBTI data',
-      error: err,
     });
   }
 };
@@ -86,23 +98,28 @@ export const getMbtiText = async (req, res) => {
 
   try {
     const [rows] = await pool.execute(query, [userId]);
-    if (rows.length > 0) {
-      const mbtiData = rows[0].mbti;
-      mbtiData.extrovert >= 50 ? (MBTI += 'E') : (MBTI += 'I');
-      mbtiData.sensing >= 50 ? (MBTI += 'S') : (MBTI += 'N');
-      mbtiData.thinking >= 50 ? (MBTI += 'T') : (MBTI += 'F');
-      mbtiData.judging >= 50 ? (MBTI += 'J') : (MBTI += 'P');
 
-      res.status(StatusCodes.OK).json({ MBTI });
-    } else {
-      res.status(StatusCodes.NOT_FOUND).json({
+    if (rows.length === 0) {
+      return res.status(StatusCodes.NOT_FOUND).json({
+        sucess: false,
+        status: StatusCodes.NOT_FOUND,
         message: 'MBTI not found',
       });
     }
-  } catch (err) {
+
+    const mbtiData = rows[0].mbti;
+    mbtiData.extrovert >= 50 ? (MBTI += 'E') : (MBTI += 'I');
+    mbtiData.sensing >= 50 ? (MBTI += 'S') : (MBTI += 'N');
+    mbtiData.thinking >= 50 ? (MBTI += 'T') : (MBTI += 'F');
+    mbtiData.judging >= 50 ? (MBTI += 'J') : (MBTI += 'P');
+
+    res.status(StatusCodes.OK).json({ MBTI });
+  } catch (error) {
+    console.log(error);
     res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      sucess: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
       message: 'Failed to retrieve MBTI data',
-      error: err,
     });
   }
 };
@@ -132,7 +149,7 @@ export async function getMbti(mbti_data) {
     } else {
       return { message: 'Failed to update MBTI' };
     }
-  } catch (err) {
+  } catch (error) {
     throw new Error('Failed to update MBTI');
   }
 }

--- a/controller/QuestionController.js
+++ b/controller/QuestionController.js
@@ -15,25 +15,38 @@ export const addQuestion = async (req, res) => {
     order_num,
     required,
   ];
-  let [questions_results] = await pool.execute(questions_sql, questions_values);
-  let question_id = questions_results.insertId;
 
-  // question_options 테이블 삽입
-  let question_options_sql = `INSERT INTO question_options (question_id, option_text, question_num) VALUES ?;`;
+  try {
+    let [questions_results] = await pool.execute(
+      questions_sql,
+      questions_values,
+    );
+    let question_id = questions_results.insertId;
 
-  // items는 배열로 받아오기 때문에 요소들을 하나씩 꺼냄
-  let question_options_values = options.map((options) => [
-    question_id,
-    options.option_text,
-    options.question_num,
-  ]);
+    // question_options 테이블 삽입
+    let question_options_sql = `INSERT INTO question_options (question_id, option_text, question_num) VALUES ?;`;
 
-  // 오류가 발생할 수 있으므로 query로 계속 진행
-  let [question_options_results] = await pool.query(question_options_sql, [
-    question_options_values,
-  ]);
+    // items는 배열로 받아오기 때문에 요소들을 하나씩 꺼냄
+    let question_options_values = options.map((options) => [
+      question_id,
+      options.option_text,
+      options.question_num,
+    ]);
 
-  return res.status(StatusCodes.OK).json(question_options_results);
+    // 오류가 발생할 수 있으므로 query로 계속 진행
+    let [question_options_results] = await pool.query(question_options_sql, [
+      question_options_values,
+    ]);
+
+    return res.status(StatusCodes.OK).json(question_options_results);
+  } catch (error) {
+    console.log(error);
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      message: 'Failed to add question',
+    });
+  }
 };
 
 export const allQuestion = async (req, res) => {
@@ -47,12 +60,20 @@ export const allQuestion = async (req, res) => {
     const [rows, fields] = await pool.execute(sql, surveyId);
 
     if (rows.length === 0) {
-      return res.status(StatusCodes.NOT_FOUND).end();
+      return res.status(StatusCodes.NOT_FOUND).json({
+        success: false,
+        status: StatusCodes.NOT_FOUND,
+        message: 'Question not found',
+      });
     }
     return res.status(StatusCodes.OK).json(rows);
   } catch (error) {
     console.log(error);
-    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      message: 'Failed to get question',
+    });
   }
 };
 
@@ -72,13 +93,21 @@ export const editQuestion = async (req, res) => {
     const [rows, fields] = await pool.execute(sql, values);
 
     if (rows.affectedRows === 0) {
-      return res.status(StatusCodes.NOT_FOUND).end();
+      return res.status(StatusCodes.NOT_FOUND).json({
+        success: false,
+        status: StatusCodes.NOT_FOUND,
+        message: 'Question not found',
+      });
     }
 
     return res.status(StatusCodes.OK).end();
   } catch (error) {
     console.log(error);
-    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      message: 'Failed to edit question',
+    });
   }
 };
 
@@ -103,13 +132,21 @@ export const editOptions = async (req, res) => {
     const [rows, fields] = await pool.execute(sql, values);
 
     if (rows.affectedRows === 0) {
-      return res.status(StatusCodes.NOT_FOUND).end();
+      return res.status(StatusCodes.NOT_FOUND).json({
+        success: false,
+        status: StatusCodes.NOT_FOUND,
+        message: 'Option not found',
+      });
     }
 
     return res.status(StatusCodes.OK).end();
   } catch (error) {
     console.log(error);
-    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      message: 'Failed to edit option',
+    });
   }
 };
 
@@ -123,13 +160,21 @@ export const deleteQuestion = async (req, res) => {
     const [rows, fields] = await pool.execute(question_sql, questionId);
 
     if (rows.affectedRows === 0) {
-      return res.status(StatusCodes.NOT_FOUND).end();
+      return res.status(StatusCodes.NOT_FOUND).json({
+        success: false,
+        status: StatusCodes.NOT_FOUND,
+        message: 'Question not found',
+      });
     }
 
     return res.status(StatusCodes.OK).end();
   } catch (error) {
     console.log(error);
-    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      message: 'Failed to delete question',
+    });
   }
 };
 // ???
@@ -144,12 +189,20 @@ export const deleteOption = async (req, res) => {
     const [rows, fields] = await pool.execute(option_sql, optionId);
 
     if (rows.affectedRows === 0) {
-      return res.status(StatusCodes.NOT_FOUND).end();
+      return res.status(StatusCodes.NOT_FOUND).json({
+        success: false,
+        status: StatusCodes.NOT_FOUND,
+        message: 'Option not found',
+      });
     }
 
     return res.status(StatusCodes.OK).end();
   } catch (error) {
     console.log(error);
-    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      message: 'Failed to delete option',
+    });
   }
 };

--- a/controller/StatController.js
+++ b/controller/StatController.js
@@ -74,7 +74,12 @@ export const showMostChoiced = async (req, res) => {
     }
     res.status(StatusCodes.OK).json(result);
   } catch (error) {
-    res.status(StatusCodes.BAD_REQUEST).end();
+    console.log(error);
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      message: 'Failed to show most choiced',
+    });
   }
 };
 
@@ -101,6 +106,10 @@ export const showResult = async (req, res) => {
     });
     res.status(StatusCodes.OK).json(result);
   } catch (error) {
-    res.status(StatusCodes.BAD_REQUEST).end();
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      message: 'Failed to show result',
+    });
   }
 };

--- a/controller/StatController.js
+++ b/controller/StatController.js
@@ -2,32 +2,31 @@ import pool from '../mariadb.js';
 import { StatusCodes } from 'http-status-codes';
 
 export const showMostChoiced = async (req, res) => {
+  const { survey_id } = req.params;
+  let { mbti } = req.query;
   try {
-    const surveyId = req.params.surveyId;
-    let { mbti } = req.query;
     mbti = mbti === 'true';
 
-    let surveyTitle, totalVoteCount, mostChoiced;
     let mostChoicedNames = [];
 
-    [surveyTitle] = await pool.execute(
+    const [surveyTitle] = await pool.execute(
       `SELECT title FROM surveys WHERE id = ?`,
-      [surveyId],
+      [survey_id],
     );
 
-    [totalVoteCount] = await pool.execute(
+    const [totalVoteCount] = await pool.execute(
       `SELECT count(*) FROM responses WHERE survey_id = ?`,
-      [surveyId],
+      [survey_id],
     );
 
-    [mostChoiced] = await pool.execute(
+    const [mostChoiced] = await pool.execute(
       `WITH OptionCounts AS (
     SELECT option_id, COUNT(*) AS count
     FROM answer_choices
     WHERE response_id IN (SELECT id FROM responses WHERE survey_id = ?)
     GROUP BY option_id) SELECT option_id, count
     FROM OptionCounts WHERE count = (SELECT MAX(count) FROM OptionCounts);`,
-      [surveyId],
+      [survey_id],
     );
 
     for (let answer of mostChoiced) {
@@ -84,11 +83,13 @@ export const showMostChoiced = async (req, res) => {
 };
 
 export const showResult = async (req, res) => {
-  const surveyId = req.params.surveyId;
+  const { survey_id } = req.params;
+
+  console.log(survey_id);
   try {
-    let sql = `SELECT option_id, COUNT(*) AS count FROM answer_choices
+    const sql = `SELECT option_id, COUNT(*) AS count FROM answer_choices
              WHERE question_id = ? GROUP BY option_id; `;
-    const [optionsCount] = await pool.execute(sql, [surveyId]);
+    const [optionsCount] = await pool.execute(sql, [survey_id]);
 
     const result = [];
     for (let option of optionsCount) {
@@ -106,6 +107,7 @@ export const showResult = async (req, res) => {
     });
     res.status(StatusCodes.OK).json(result);
   } catch (error) {
+    console.log(error);
     res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
       success: false,
       status: StatusCodes.INTERNAL_SERVER_ERROR,

--- a/controller/UserController.js
+++ b/controller/UserController.js
@@ -16,13 +16,21 @@ export async function searchUsers(req, res) {
     );
 
     if (rows.length === 0) {
-      return res.status(StatusCodes.NOT_FOUND).end();
+      return res.status(StatusCodes.NOT_FOUND).json({
+        success: false,
+        status: StatusCodes.NOT_FOUND,
+        message: 'No users found',
+      });
     }
 
     return res.status(StatusCodes.OK).send(rows);
-  } catch (err) {
-    console.log(err);
-    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+  } catch (error) {
+    console.log(error);
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      message: 'Failed to search users',
+    });
   }
 }
 
@@ -54,10 +62,22 @@ export async function createUser(req, res) {
         mbti,
       ],
     );
+
+    if (rows.affectedRows === 0) {
+      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        status: StatusCodes.INTERNAL_SERVER_ERROR,
+        message: 'Failed to create user',
+      });
+    }
     return res.status(StatusCodes.CREATED).end();
-  } catch (err) {
-    console.log(err);
-    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+  } catch (error) {
+    console.log(error);
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      message: 'Failed to create user',
+    });
   }
 }
 
@@ -72,13 +92,21 @@ export async function getUser(req, res) {
     );
 
     if (rows.length === 0) {
-      return res.status(StatusCodes.NOT_FOUND).end();
+      return res.status(StatusCodes.NOT_FOUND).json({
+        success: false,
+        status: StatusCodes.NOT_FOUND,
+        message: 'User not found',
+      });
     }
 
     return res.status(StatusCodes.OK).send(rows[0]);
-  } catch (err) {
-    console.log(err);
-    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+  } catch (error) {
+    console.log(error);
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      message: 'Failed to get user',
+    });
   }
 }
 
@@ -88,7 +116,11 @@ export async function getMyProfile(req, res) {
   const token = req.cookies.token;
 
   if (!token) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED).json({
+      success: false,
+      status: StatusCodes.UNAUTHORIZED,
+      message: 'Unauthorized',
+    });
   }
 
   const JWT_SECRET = process.env.JWT_SECRET;
@@ -96,20 +128,27 @@ export async function getMyProfile(req, res) {
   try {
     const decoded = jwt.verify(token, JWT_SECRET);
 
-    console.log(decoded);
     const [rows, fields] = await pool.execute(
       `SELECT id, username, email, email_verified, promotion_email_consent, mbti FROM users WHERE id = ?`,
       [decoded.id],
     );
 
     if (rows.length === 0) {
-      return res.status(StatusCodes.NOT_FOUND).json('User not found');
+      return res.status(StatusCodes.NOT_FOUND).json({
+        success: false,
+        status: StatusCodes.NOT_FOUND,
+        message: 'User not found',
+      });
     }
 
     return res.status(StatusCodes.OK).send(rows[0]);
-  } catch (err) {
-    console.log(err);
-    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+  } catch (error) {
+    console.log(error);
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      message: 'Failed to get user',
+    });
   }
 }
 
@@ -120,7 +159,11 @@ export async function updateMyProfile(req, res) {
   const token = req.cookies.token;
 
   if (!token) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED).json({
+      success: false,
+      status: StatusCodes.UNAUTHORIZED,
+      message: 'Unauthorized',
+    });
   }
 
   const JWT_SECRET = process.env.JWT_SECRET;
@@ -156,10 +199,22 @@ export async function updateMyProfile(req, res) {
 
     await pool.execute(sql, values);
 
+    if (rows.affectedRows === 0) {
+      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        status: StatusCodes.INTERNAL_SERVER_ERROR,
+        message: 'Failed to update user',
+      });
+    }
+
     return res.status(StatusCodes.OK).end();
-  } catch (err) {
-    console.log(err);
-    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+  } catch (error) {
+    console.log(error);
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      message: 'Failed to update user',
+    });
   }
 }
 
@@ -168,7 +223,11 @@ export async function deleteMyAccount(req, res) {
   const token = req.cookies.token;
 
   if (!token) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED).json({
+      success: false,
+      status: StatusCodes.UNAUTHORIZED,
+      message: 'Unauthorized',
+    });
   }
 
   const JWT_SECRET = process.env.JWT_SECRET;
@@ -178,10 +237,22 @@ export async function deleteMyAccount(req, res) {
 
     await pool.execute(`DELETE FROM users WHERE id = ?`, [decoded.id]);
 
+    if (rows.affectedRows === 0) {
+      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        status: StatusCodes.INTERNAL_SERVER_ERROR,
+        message: 'Failed to delete user',
+      });
+    }
+
     return res.status(StatusCodes.NO_CONTENT).end();
-  } catch (err) {
-    console.log(err);
-    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+  } catch (error) {
+    console.log(error);
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      message: 'Failed to delete user',
+    });
   }
 }
 
@@ -191,7 +262,11 @@ export async function changeMyPassword(req, res) {
   const token = req.cookies.token;
 
   if (!token) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED).json({
+      success: false,
+      status: StatusCodes.UNAUTHORIZED,
+      message: 'Unauthorized',
+    });
   }
 
   const JWT_SECRET = process.env.JWT_SECRET;
@@ -213,10 +288,22 @@ export async function changeMyPassword(req, res) {
       [passwordHash, passwordSalt, decoded.id],
     );
 
+    if (rows.affectedRows === 0) {
+      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        status: StatusCodes.INTERNAL_SERVER_ERROR,
+        message: 'Failed to change password',
+      });
+    }
+
     return res.status(StatusCodes.OK).end();
-  } catch (err) {
-    console.log(err);
-    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+  } catch (error) {
+    console.log(error);
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      message: 'Failed to change password',
+    });
   }
 }
 
@@ -232,7 +319,11 @@ export async function login(req, res) {
     );
 
     if (rows.length === 0) {
-      return res.status(StatusCodes.NOT_FOUND).end();
+      return res.status(StatusCodes.NOT_FOUND).json({
+        success: false,
+        status: StatusCodes.NOT_FOUND,
+        message: 'User not found',
+      });
     }
 
     const user = rows[0];
@@ -245,7 +336,11 @@ export async function login(req, res) {
     ).toString('base64');
 
     if (passwordHash !== user.password_hash) {
-      return res.status(StatusCodes.NOT_FOUND).end(); // 보안상의 이유로 UNAUTHORIZED대신 NOT_FOUND를 응답해도 됨
+      return res.status(StatusCodes.NOT_FOUND).json({
+        success: false,
+        status: StatusCodes.NOT_FOUND,
+        message: 'User not found',
+      }); // 보안상의 이유로 UNAUTHORIZED대신 NOT_FOUND를 응답해도 됨
     }
 
     const JWT_SECRET = process.env.JWT_SECRET;
@@ -273,9 +368,13 @@ export async function login(req, res) {
     });
 
     return res.status(StatusCodes.OK).json({ user: safeUser });
-  } catch (err) {
-    console.log(err);
-    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+  } catch (error) {
+    console.log(error);
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      message: 'Failed to login',
+    });
   }
 }
 
@@ -284,7 +383,11 @@ export async function logout(req, res) {
   const token = req.cookies.token;
 
   if (!token) {
-    return res.status(StatusCodes.OK).end();
+    return res.status(StatusCodes.OK).json({
+      success: false,
+      status: StatusCodes.OK,
+      message: 'Already logged out',
+    });
   }
 
   res.clearCookie('token');
@@ -310,8 +413,12 @@ export async function checkEmailExists(req, res) {
     return res
       .status(StatusCodes.OK)
       .send({ message: '사용 가능한 이메일입니다.' });
-  } catch (err) {
-    console.log(err);
-    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+  } catch (error) {
+    console.log(error);
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      message: 'Failed to check email',
+    });
   }
 }

--- a/controller/UserController.js
+++ b/controller/UserController.js
@@ -49,7 +49,7 @@ export async function createUser(req, res) {
   const choseong = getChoseong(userName);
 
   try {
-    await pool.execute(
+    const [rows, fields] = await pool.execute(
       `INSERT INTO users (username, email, password_hash, password_salt, choseong, promotion_email_consent, mbti)
       VALUES (?, ?, ?, ?, ?, ?, ?)`,
       [

--- a/controller/responsesController.js
+++ b/controller/responsesController.js
@@ -12,13 +12,21 @@ export const createResponse = async (req, res) => {
 
       const [rows, fields] = await pool.execute(
         'INSERT INTO responses (survey_id, user_id, question_id, option_id, answer_text) VALUES (?, ?, ?, ?, ?)',
-        [surveyId, user_id, question_id, option_id || null, answer_text || null],
+        [
+          surveyId,
+          user_id,
+          question_id,
+          option_id || null,
+          answer_text || null,
+        ],
       );
 
       if (rows.affectedRows === 0) {
-        return res
-          .status(StatusCodes.INTERNAL_SERVER_ERROR)
-          .json({ error: 'Failed to submit response' });
+        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+          success: false,
+          status: StatusCodes.INTERNAL_SERVER_ERROR,
+          message: 'Failed to submit response',
+        });
       }
 
       return res
@@ -27,9 +35,11 @@ export const createResponse = async (req, res) => {
     }
   } catch (error) {
     console.log(error);
-    return res
-      .status(StatusCodes.INTERNAL_SERVER_ERROR)
-      .json({ error: 'Failed to submit response' });
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      message: 'Failed to submit response',
+    });
   }
 };
 
@@ -45,9 +55,11 @@ export const editResponse = async (req, res) => {
       [response_id],
     );
     if (rows.affectedRows === 0) {
-      return res
-        .status(StatusCodes.INTERNAL_SERVER_ERROR)
-        .json({ error: 'Failed to delete previous responses' });
+      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        status: StatusCodes.INTERNAL_SERVER_ERROR,
+        message: 'Failed to update responses',
+      });
     }
 
     // 2. 수정된 answers 데이터를 responses 테이블에 다시 삽입
@@ -78,9 +90,11 @@ export const editResponse = async (req, res) => {
       .json({ message: 'Response updated successfully' });
   } catch (error) {
     console.log(error);
-    return res
-      .status(StatusCodes.INTERNAL_SERVER_ERROR)
-      .json({ error: 'Failed to update responses' });
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      error: 'Failed to update',
+    });
   }
 };
 
@@ -93,10 +107,24 @@ export const deleteResponse = async (req, res) => {
       'DELETE FROM responses WHERE id = ?',
       [response_id],
     );
+
+    if (rows.affectedRows === 0) {
+      return res.status(StatusCodes.NOT_FOUND).json({
+        success: false,
+        status: StatusCodes.NOT_FOUND,
+        message: 'Response not found',
+      });
+    }
+
+    return res.status(StatusCodes.OK).json({
+      message: 'Response deleted successfully',
+    });
   } catch (error) {
     console.log(error);
-    return res
-      .status(StatusCodes.INTERNAL_SERVER_ERROR)
-      .json({ error: 'Failed to delete response' });
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      status: StatusCodes.INTERNAL_SERVER_ERROR,
+      message: 'Failed to delete response',
+    });
   }
 };

--- a/controller/surveysController.js
+++ b/controller/surveysController.js
@@ -68,11 +68,14 @@ export const getSurveys = (req, res) => {
 };
 
 // 개별 설문조사 조회하기 (GET /surveys/:survey_id)
-export const getSurveyById = (req, res) => {
+export const getSurveyById = async (req, res) => {
   const { survey_id } = req.params;
 
   try {
-    const [rows, fields] = await pool.execute('SELECT * FROM surveys WHERE id = ?', [survey_id]);
+    const [rows, fields] = await pool.execute(
+      'SELECT * FROM surveys WHERE id = ?',
+      [survey_id],
+    );
 
     if (rows.length === 0) {
       return res.status(StatusCodes.NOT_FOUND).json({
@@ -83,7 +86,6 @@ export const getSurveyById = (req, res) => {
     }
 
     return res.status(StatusCodes.OK).json(rows[0]);
-
   } catch (error) {
     console.log(error);
     return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
@@ -95,7 +97,7 @@ export const getSurveyById = (req, res) => {
 };
 
 // 설문조사 수정하기 (PUT /surveys/:survey_id)
-export const updateSurvey = (req, res) => {
+export const updateSurvey = async (req, res) => {
   const { survey_id } = req.params;
   const { title, description, expires_at } = req.body;
 
@@ -113,7 +115,9 @@ export const updateSurvey = (req, res) => {
       });
     }
 
-    return res.status(StatusCodes.OK).json({ message: 'Survey updated successfully' });
+    return res
+      .status(StatusCodes.OK)
+      .json({ message: 'Survey updated successfully' });
   } catch (error) {
     console.log(error);
     return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
@@ -125,13 +129,16 @@ export const updateSurvey = (req, res) => {
 };
 
 // 설문조사 삭제하기 (DELETE /surveys/:survey_id)
-export const deleteSurvey = (req, res) => {
+export const deleteSurvey = async (req, res) => {
   const { survey_id } = req.params;
 
   try {
-    const [rows, fields] = await pool.execute('DELETE FROM surveys WHERE id = ?', [survey_id]);
+    const [rows, fields] = await pool.execute(
+      'DELETE FROM surveys WHERE id = ?',
+      [survey_id],
+    );
 
-    if(rows.affectedRows === 0) {
+    if (rows.affectedRows === 0) {
       return res.status(StatusCodes.NOT_FOUND).json({
         success: false,
         status: StatusCodes.NOT_FOUND,
@@ -139,8 +146,9 @@ export const deleteSurvey = (req, res) => {
       });
     }
 
-    return res.status(StatusCodes.OK).json({ message: 'Survey deleted successfully' });
-
+    return res
+      .status(StatusCodes.OK)
+      .json({ message: 'Survey deleted successfully' });
   } catch (error) {
     console.log(error);
     return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,34 @@
         "eslint": "^9.12.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
+        "eslint-plugin-unicorn": "^56.0.0",
         "nodemon": "^3.1.7",
         "prettier": "^3.3.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.0.tgz",
+      "integrity": "sha512-INCKxTtbXtcNbUZ3YXutwMpEleqttcswhAdee7dhuoVrD2cnuc3PqtERBtxkX5nziX9vnBL8WXmSGwv8CuPV6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -272,6 +298,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -445,11 +478,57 @@
         "node": ">=8"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.24.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
+      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001669",
+        "electron-to-chromium": "^1.5.41",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.1"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -488,6 +567,27 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001671",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001671.tgz",
+      "integrity": "sha512-jocyVaSSfXg2faluE6hrWkMgDOiULBMca4QLtDT39hw1YxaIPHWc1CcTCKkPmHgGH6tKji6ZNbMSmUAvENf2/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -552,6 +652,45 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
+      "integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clean-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
+      "integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/clean-regexp/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/color-convert": {
@@ -638,6 +777,20 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/core-js-compat": {
+      "version": "3.38.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.1.tgz",
+      "integrity": "sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.23.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -742,6 +895,13 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.47",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.47.tgz",
+      "integrity": "sha512-zS5Yer0MOYw4rtK2iq43cJagHZ8sXN0jDHDKzB+86gSBSAI4v07S97mcq+Gs2vclAxSh1j7vOAHxSVgduiiuVQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -749,6 +909,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-define-property": {
@@ -770,6 +940,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -894,6 +1074,53 @@
         "eslint-config-prettier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-unicorn": {
+      "version": "56.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-56.0.0.tgz",
+      "integrity": "sha512-aXpddVz/PQMmd69uxO98PA4iidiVNvA0xOtbpUoz1WhBd4RxOQQYqN618v68drY0hmy5uU2jy1bheKEVWBjlPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.24.7",
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "ci-info": "^4.0.0",
+        "clean-regexp": "^1.0.0",
+        "core-js-compat": "^3.38.1",
+        "esquery": "^1.6.0",
+        "globals": "^15.9.0",
+        "indent-string": "^4.0.0",
+        "is-builtin-module": "^3.2.1",
+        "jsesc": "^3.0.2",
+        "pluralize": "^8.0.0",
+        "read-pkg-up": "^7.0.1",
+        "regexp-tree": "^0.1.27",
+        "regjsparser": "^0.10.0",
+        "semver": "^7.6.3",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.56.0"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/globals": {
+      "version": "15.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.11.0.tgz",
+      "integrity": "sha512-yeyNSjdbyVaWurlwCpcA6XNBrHTMIeDdj0/hnvX/OLJ9ekOXYbLsLinH/MucQyGvNnXhidTdNhTtJaffL2sMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-scope": {
@@ -1368,6 +1595,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -1446,6 +1680,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1461,6 +1705,13 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1472,6 +1723,38 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -1520,6 +1803,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -1533,10 +1823,30 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1626,6 +1936,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -1788,6 +2105,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -1867,6 +2194,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nodemon": {
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.7.tgz",
@@ -1920,6 +2254,29 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -2005,6 +2362,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2016,6 +2383,25 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parseurl": {
@@ -2047,11 +2433,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
       "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
       "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -2064,6 +2464,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/prelude-ls": {
@@ -2174,6 +2584,106 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -2185,6 +2695,56 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
+    "node_modules/regjsparser": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.10.0.tgz",
+      "integrity": "sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "jsesc": "~0.5.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/regjsparser/node_modules/jsesc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-from": {
@@ -2371,6 +2931,42 @@
         "node": ">=10"
       }
     },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.20",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz",
+      "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/sqlstring": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
@@ -2387,6 +2983,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -2413,6 +3022,19 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/synckit": {
@@ -2491,6 +3113,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -2520,6 +3152,37 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -2537,6 +3200,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "node_modules/validator": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "eslint": "^9.12.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
+    "eslint-plugin-unicorn": "^56.0.0",
     "nodemon": "^3.1.7",
     "prettier": "^3.3.3"
   }

--- a/routes/stats.js
+++ b/routes/stats.js
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { showResult, showMostChoiced } from '../controller/statController.js';
+import { showResult, showMostChoiced } from '../Controller/StatController.js';
 
 const router = Router({ mergeParams: true });
 


### PR DESCRIPTION
## 📋 Pull Request 제목

- 일관된 에러 처리 적용
- 리스폰스 API 리팩토링 /

## 📝 변경 사항

- 에러 발생시 일관되게 console.log(error)하고 일관된 메세지를 response에 담아 보냅니다.
`{
      success: false,
      status: StatusCodes.INTERNAL_SERVER_ERROR,
      message: 'Failed to show result',
    }`
- 리스폰스 API에서 createResponse 시 response 테이블만 사용하던 것을 response와 answer_choices 두 테이블로 분리했습니다.
이는 stats api 에서 분리된 테이블 사용하는 것을 전제로 하고, stats api를 수정하는 것보다 이게 쉬워서 그렇게 리팩토링 함.
사용한 sql은 노션에.
- 스탯 api가 잘 작동하는지 테스트 했습니다. 노션에 기록해주신 세가지 다 기능다 정상 작동. 스크린샷 참조.

## ✅ 체크리스트

- [] 코드에 주석을 추가했나요?
- [] 새로운 기능 또는 버그 수정이 해당 문서에 반영되었나요?
- [] 디버그를 위해 작성해둔 log를 지웠나요?
- [] 불필요한 코드를 남겨두진 않았나요?

## 📸 변경된 UI나 API 응답 (필요시)
- 설문에 응답하기 : OK
    
     POST /surveys/:survey_id/responses


<img width="811" alt="스크린샷 2024-10-26 오후 6 04 53" src="https://github.com/user-attachments/assets/255de6b8-5050-43b3-b970-aeeafa849996">

- 각 선택지 별 득표수 확인하기: OK
    
    GET /surveys/:survey_id/stats

<img width="893" alt="스크린샷 2024-10-26 오후 6 22 10" src="https://github.com/user-attachments/assets/06716fe0-0a16-4db1-bcb7-73934131727a">

    
- 가장 많은 득표수 받은 선택지(1등) 확인하기 : OK
    
    GET /surveys/:survey_id/stats/detail
    
<img width="828" alt="스크린샷 2024-10-26 오후 6 23 04" src="https://github.com/user-attachments/assets/4112ee78-2609-4dd6-a372-206bebad2160">


- 1등 선택지 및 응답자 MBTI 확인하기 : OK
    
    GET /surveys/:survey_id/stats/detail?mbti=true

<img width="928" alt="스크린샷 2024-10-26 오후 6 23 45" src="https://github.com/user-attachments/assets/d6cf8ebd-01e6-4c97-9f58-77d06f34523b">



## 🚧 주의 사항
